### PR TITLE
changed-timeout-salt_update_and_reboot

### DIFF
--- a/uyuni-tools/system_update.py
+++ b/uyuni-tools/system_update.py
@@ -53,6 +53,7 @@ def do_update_minion(updateble_patches):
         smt.log_info('No update for salt-minion"')
         return
     smt.system_scheduleapplyerrate(patches, datetime.datetime.now(), "SALT minion update", "minor")
+    time.sleep(20)
     smt.system_schedulepackagerefresh(datetime.datetime.now())
     return
 
@@ -131,6 +132,7 @@ def do_upgrade(no_reboot, force_reboot):
         smt.log_debug("Option force_reboot given")
     if not no_reboot and reboot_needed_package and reboot_needed_errata:
         smt.system_schedulereboot(datetime.datetime.now())
+        time.sleep(30)
     smt.system_schedulehardwarerefresh(datetime.datetime.now(), True)
     return
 


### PR DESCRIPTION
There have been instances reported that the the start from the salt-minion, or rather SUSE Manager knowing that salt-minion, is up again, that planned actions are reported as failed. This happens after updating the salt-minion itself and after rebooting the server.

Michael