### PR TITLE
Change the script for reactivation proxy clients to use the salt-bundle

### DIFF
--- a/uyuni-tools/reactivate_proxy_clients.py
+++ b/uyuni-tools/reactivate_proxy_clients.py
@@ -58,13 +58,18 @@ if __name__ == "__main__":
 
     client_mapping = suma_rpc.system.getMinionIdMap(key)
     suma_salt = salt.client.LocalClient()
-    res = suma_salt.cmd_iter("master:{}".format(args.proxy_fqdn), "grains.item", ["id"], tgt_type="grain", timeout = 2)
+    res = suma_salt.cmd_iter("master:{}".format(args.proxy_fqdn), "grains.item", ["id", "saltpath"], tgt_type="grain", timeout = 2)
     for c in res:
         nclients += 1
         if maxclients < nclients:
             break
+        
+        salt_ret = list(c.values())[0]["ret"]
+        c_saltid = salt_ret["id"]
+        c_configpath = "/etc/venv-salt-minion/minion.d/susemanager.conf" \
+            if "venv" in salt_ret.get("saltpath", "") \
+            else "/etc/salt/minion.d/susemanager.conf"
 
-        c_saltid = list(c.values())[0]["ret"]["id"]
         print('Processing salt client {}'.format(c_saltid))
         c_id = client_mapping.get(c_saltid)
         if c_id is None:
@@ -85,10 +90,10 @@ if __name__ == "__main__":
             print('DRYRUN: suma_rpc.system.obtainReactivationKey(key, {})'.format(c_id))
         else:
             c_key = suma_rpc.system.obtainReactivationKey(key, c_id)
-        clients.append((c_saltid, c_key))
+        clients.append((c_saltid, c_configpath, c_key))
 
-    for c, r in clients:
-        sed_cmd = "sed -i -e 's/^\(\s*\)susemanager:.*$/\\1susemanager:\\n\\1    management_key: {}/' /etc/venv-salt-minion/minion.d/susemanager.conf".format(r)
+    for c, p, r in clients:
+        sed_cmd = "sed -i -e 's/^\(\s*\)susemanager:.*$/\\1susemanager:\\n\\1    management_key: {}/' {}".format(r, p)
         if args.dryrun:
             print('DRYRUN: suma_salt.cmd({}, "cmd.run", ["{}"])'.format(c, sed_cmd))
             print('DRYRUN: suma_salt.cmd({}, "cmd.run_bg", ["sleep 2;service salt-minion restart"])'.format(c))

--- a/uyuni-tools/reactivate_proxy_clients.py
+++ b/uyuni-tools/reactivate_proxy_clients.py
@@ -88,7 +88,7 @@ if __name__ == "__main__":
         clients.append((c_saltid, c_key))
 
     for c, r in clients:
-        sed_cmd = "sed -i -e 's/^\(\s*\)susemanager:.*$/\\1susemanager:\\n\\1    management_key: {}/' /etc/salt/minion.d/susemanager.conf".format(r)
+        sed_cmd = "sed -i -e 's/^\(\s*\)susemanager:.*$/\\1susemanager:\\n\\1    management_key: {}/' /etc/venv-salt-minion/minion.d/susemanager.conf".format(r)
         if args.dryrun:
             print('DRYRUN: suma_salt.cmd({}, "cmd.run", ["{}"])'.format(c, sed_cmd))
             print('DRYRUN: suma_salt.cmd({}, "cmd.run_bg", ["sleep 2;service salt-minion restart"])'.format(c))


### PR DESCRIPTION
Account for a salt-bundle case when reactivating proxy clients.
Decide on the location of the `susemanager.conf` based on the `saltpath` in grains