### PR TITLE
Make contrib group the codeowners for the whole repository

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,36 @@
+# CODEOWNERS info & syntax
+# Lines starting with "#" are comments.
+#
+# Each line is a file pattern followed by one or more owners.
+#
+# Order is important; the last matching pattern takes the most
+# precedence.
+#
+# Owners can be specified by email address or GitHub username
+#
+# Teams can be specified as code owners as well. Teams should
+# be identified in the format @org/team-name. Teams must have
+# explicit write access to the repository.
+#
+# Patterns
+#
+# Whole repository
+# * @global-owner
+#
+# Directory (without subdirectories)
+# docs/* @tech_writer
+#
+# Directory (including subdirectories)
+# apps/ @app_developer
+#
+# Adding a leading "/" to a pattern means the directory must
+# be in the root of the repository.
+#
+# Empty Pattern -> no owner (@app_developer owns all of apps/ except apps/github)
+# apps/ @app_developer
+# apps/github
+
+# Uyuni Code Owners
+
+* @uyuni-project/contrib
+/.github/ @uyuni-project/contrib


### PR DESCRIPTION
As title mentions.

With this, the default for PR reviews will be:
- GitHub will automatically assign the group `contrib` to any PR for this repository
- People in that group will get notifications (only @mbrookhuis for now)
- People in that group must then review, approve if everything is OK, then merge.

If needed, other Uyuni developers can be added as reviewers, and they will still have rights to merge.



