### PR TITLE
use universal instead of local time

### DIFF
--- a/uyuni-tools/create_software_project.py
+++ b/uyuni-tools/create_software_project.py
@@ -69,8 +69,8 @@ def create_project(project, environment, basechannel, addchannel, description):
     Create a new software project
     """
     if not description:
-        dat = ("%s-%02d-%02d" % (datetime.datetime.now().year, datetime.datetime.now().month,
-                                 datetime.datetime.now().day))
+        dat = ("%s-%02d-%02d" % (datetime.datetime.utcnow().year, datetime.datetime.utcnow().month,
+                                 datetime.datetime.utcnow().day))
         description = "Created on {}".format(dat)
     smt.log_info("Creating project {}".format(project))
     smt.contentmanagement_createproject(project, project, description)

--- a/uyuni-tools/cve_report.py
+++ b/uyuni-tools/cve_report.py
@@ -73,7 +73,7 @@ def get_cve_content(args):
     Get CVE content.
     """
     smt.log_info("")
-    smt.log_info("Start {}".format(datetime.datetime.now()))
+    smt.log_info("Start {}".format(datetime.datetime.utcnow()))
     smt.log_info("")
     smt.log_info("Given list of CVEs: {}".format(args.cve))
     smt.log_info("")

--- a/uyuni-tools/do_package_update.py
+++ b/uyuni-tools/do_package_update.py
@@ -90,7 +90,7 @@ def do_package_update(server_id):
         result = check_progress(ai)
     if result == 0:
         try:
-            ai = smt.client.system.schedulePackageRefresh(smt.session, server_id, datetime.datetime.now())
+            ai = smt.client.system.schedulePackageRefresh(smt.session, server_id, datetime.datetime.utcnow())
         except xmlrpc.client.Fault as err:
             smt.log_info("unable to schedule package refresh for server. Error: {}".format(err))
             return 2
@@ -113,7 +113,7 @@ def apply_updates_regular(sd):
     for x in alluprpms:
         rpms.append(x.get('to_package_id'))
     try:
-        actionid = smt.client.system.schedulePackageInstall(smt.session, sd, rpms, datetime.datetime.now())
+        actionid = smt.client.system.schedulePackageInstall(smt.session, sd, rpms, datetime.datetime.utcnow())
     except xmlrpc.client.Fault:
         smt.log_info('Unable to add package to chain')
         return 2

--- a/uyuni-tools/smtools.py
+++ b/uyuni-tools/smtools.py
@@ -168,7 +168,7 @@ class SMTools:
             smtp_connection = smtplib.SMTP(CONFIGSM['smtp']['server'])
         except Exception:
             self.fatal_error("error when sending mail")
-        datenow = datetime.datetime.now()
+        datenow = datetime.datetime.utcnow()
         txt = ("Dear admin,\n\nThe job {} has run today at {}.".format(script, datenow))
         txt += "\n\nUnfortunately there have been some error\n\nPlease see the following list:\n"
         txt += self.error_text
@@ -294,14 +294,14 @@ class SMTools:
         Check progress of action
         """
         (failed_count, completed_count, result_message) = self.event_status(action_id)
-        end_time = datetime.datetime.now() + datetime.timedelta(0, timeout)
+        end_time = datetime.datetime.utcnow() + datetime.timedelta(0, timeout)
         try:
             wait_time = CONFIGSM['maintenance']['wait_between_events_check']
         except:
             wait_time = 15
             self.minor_error("Please set value for maintenance | wait_between_events_check")
         while failed_count == 0 and completed_count == 0:
-            if datetime.datetime.now() > end_time:
+            if datetime.datetime.utcnow() > end_time:
                 message = "Action '{}' run in timeout. Please check server {}.".format(action, self.hostname)
                 self.error_handling('timeout_passed', message)
                 return 1, 0, message
@@ -315,7 +315,7 @@ class SMTools:
         """
         Check progress of action
         """
-        end_time = datetime.datetime.now() + datetime.timedelta(0, timeout)
+        end_time = datetime.datetime.utcnow() + datetime.timedelta(0, timeout)
         try:
             wait_time = CONFIGSM['maintenance']['wait_between_events_check']
         except:
@@ -325,7 +325,7 @@ class SMTools:
         in_progress = self.schedule_listinprogresssystems(action_id)
         while in_progress:
             self.log_info("Still Running")
-            if datetime.datetime.now() > end_time:
+            if datetime.datetime.utcnow() > end_time:
                 message = "Action '{}' run in timeout. Please check server {}.".format(action, self.hostname)
                 self.error_handling('timeout_passed', message)
                 return 1, 0, message

--- a/uyuni-tools/sync_environment.py
+++ b/uyuni-tools/sync_environment.py
@@ -36,8 +36,8 @@ def create_backup(par):
     """
     Create backup from stage
     """
-    dat = ("%s%02d%02d" % (datetime.datetime.now().year, datetime.datetime.now().month,
-                           datetime.datetime.now().day))
+    dat = ("%s%02d%02d" % (datetime.datetime.utcnow().year, datetime.datetime.utcnow().month,
+                           datetime.datetime.utcnow().day))
     clo = "bu-" + dat + "-" + par
     if smt.channel_software_getdetails(clo, True):
         smt.fatal_error('The backupchannel {} already exists. Aborting operation.'.format(clo))
@@ -84,7 +84,7 @@ def update_environment(args):
                                 if not smt.channel_software_getdetails(channel).get('parent_channel_label').startswith(channel_start):
                                     create_backup(channel)
                                     break
-                    dat = ("%s-%02d-%02d" % (datetime.datetime.now().year, datetime.datetime.now().month, datetime.datetime.now().day))
+                    dat = ("%s-%02d-%02d" % (datetime.datetime.utcnow().year, datetime.datetime.utcnow().month, datetime.datetime.utcnow().day))
                     build_message = "Created on {}".format(dat)
                     if number_in_list == 1:
                         project_env = environment_details.get('label')

--- a/uyuni-tools/sync_stage.py
+++ b/uyuni-tools/sync_stage.py
@@ -37,8 +37,8 @@ def create_backup(par):
     """
     Create backup from stage
     """
-    dat = ("%s%02d%02d" % (datetime.datetime.now().year, datetime.datetime.now().month,
-                           datetime.datetime.now().day))
+    dat = ("%s%02d%02d" % (datetime.datetime.utcnow().year, datetime.datetime.utcnow().month,
+                           datetime.datetime.utcnow().day))
     clo = "bu-" + dat + "-" + par
     if smt.channel_software_getdetails(clo, True):
         smt.fatal_error('The backupchannel {} already exists. Aborting operation.'.format(clo))
@@ -99,7 +99,7 @@ def update_project(args):
             if args.message:
                 build_message = args.message
             else:
-                dat = ("%s-%02d-%02d" % (datetime.datetime.now().year, datetime.datetime.now().month, datetime.datetime.now().day))
+                dat = ("%s-%02d-%02d" % (datetime.datetime.utcnow().year, datetime.datetime.utcnow().month, datetime.datetime.utcnow().day))
                 build_message = "Created on {}".format(dat)
             if number_in_list == 1:
                 smt.contentmanagement_buildproject(args.project, build_message)

--- a/uyuni-tools/system_rereg.py
+++ b/uyuni-tools/system_rereg.py
@@ -103,7 +103,7 @@ exit $rc""".format(proxy=proxy, key=rereg_key)
 
         else:
             script = "#!/bin/bash\nrhnreg_ks --activationkey={} --serverUrl=https://{}/XMLRPC --force\n".format(rereg_key, proxy)
-        smt.system_schedulescriptrun(script, 6000, datetime.datetime.now())
+        smt.system_schedulescriptrun(script, 6000, datetime.datetime.utcnow())
 
 
 def rereg_server(args):

--- a/uyuni-tools/system_update.py
+++ b/uyuni-tools/system_update.py
@@ -52,9 +52,9 @@ def do_update_minion(updateble_patches):
     if not patches:
         smt.log_info('No update for salt-minion"')
         return
-    smt.system_scheduleapplyerrate(patches, datetime.datetime.now(), "SALT minion update", "minor")
+    smt.system_scheduleapplyerrate(patches, datetime.datetime.utcnow(), "SALT minion update", "minor")
     time.sleep(20)
-    smt.system_schedulepackagerefresh(datetime.datetime.now())
+    smt.system_schedulepackagerefresh(datetime.datetime.utcnow())
     return
 
 
@@ -69,8 +69,8 @@ def do_update_zypper(updateble_patches):
     if not patches:
         smt.log_info('No update for zypper"')
         return
-    smt.system_scheduleapplyerrate(patches, datetime.datetime.now(), "zypper update", "minor")
-    smt.system_schedulepackagerefresh(datetime.datetime.now())
+    smt.system_scheduleapplyerrate(patches, datetime.datetime.utcnow(), "zypper update", "minor")
+    smt.system_schedulepackagerefresh(datetime.datetime.utcnow())
     return
 
 
@@ -91,8 +91,8 @@ def do_upgrade(no_reboot, force_reboot):
             patchnames.append(patch.get('advisory_name'))
         smt.log_debug("The following patches are planned:")
         smt.log_debug(patchnames)
-        smt.system_scheduleapplyerrate(patches, datetime.datetime.now(), "Errata update")
-        smt.system_schedulepackagerefresh(datetime.datetime.now())
+        smt.system_scheduleapplyerrate(patches, datetime.datetime.utcnow(), "Errata update")
+        smt.system_schedulepackagerefresh(datetime.datetime.utcnow())
         reboot_needed_errata = True
     else:
         smt.log_info('Errata update not needed. Checking for package update')
@@ -108,8 +108,8 @@ def do_upgrade(no_reboot, force_reboot):
     if rpms:
         smt.log_debug("The following packages are planned:")
         smt.log_debug(rpmnames)
-        smt.system_schedulepackageinstall(rpms, datetime.datetime.now(), "Packages update")
-        smt.system_schedulepackagerefresh(datetime.datetime.now())
+        smt.system_schedulepackageinstall(rpms, datetime.datetime.utcnow(), "Packages update")
+        smt.system_schedulepackagerefresh(datetime.datetime.utcnow())
         reboot_needed_package = True
         reboot_needed_errata = True
     else:
@@ -131,9 +131,9 @@ def do_upgrade(no_reboot, force_reboot):
     if force_reboot:
         smt.log_debug("Option force_reboot given")
     if not no_reboot and reboot_needed_package and reboot_needed_errata:
-        smt.system_schedulereboot(datetime.datetime.now())
+        smt.system_schedulereboot(datetime.datetime.utcnow())
         time.sleep(30)
-    smt.system_schedulehardwarerefresh(datetime.datetime.now(), True)
+    smt.system_schedulehardwarerefresh(datetime.datetime.utcnow(), True)
     return
 
 
@@ -180,19 +180,19 @@ def do_spmigrate(new_basechannel, no_reboot, no_dryrun):
         if no_dryrun:
             dryrun_complete = True
         else:
-            dryrun_complete = smt.system_schedulespmigration(spident, new_basechannel, checked_new_child_channels, True, datetime.datetime.now(), "SupportPack Migration dry run")
+            dryrun_complete = smt.system_schedulespmigration(spident, new_basechannel, checked_new_child_channels, True, datetime.datetime.utcnow(), "SupportPack Migration dry run")
         if dryrun_complete:
             time.sleep(20)
-            result_spmig = smt.system_schedulespmigration(spident, new_basechannel, checked_new_child_channels, False, datetime.datetime.now(), "SupportPack Migration")
+            result_spmig = smt.system_schedulespmigration(spident, new_basechannel, checked_new_child_channels, False, datetime.datetime.utcnow(), "SupportPack Migration")
         if result_spmig and not no_reboot:
             smt.log_info("Support Pack migration completed successful, rebooting server {}".format(smt.hostname))
-            smt.system_schedulereboot(datetime.datetime.now())
+            smt.system_schedulereboot(datetime.datetime.utcnow())
         elif result_spmig and no_reboot:
             smt.log_info("Support Pack migration completed successful, but server {} will not be rebooted. Please reboot manually ASAP.".format(smt.hostname))
         else:
             smt.log_error("SP Migration failed. Please check logs.")
-        smt.system_schedulepackagerefresh(datetime.datetime.now())
-        smt.system_schedulehardwarerefresh(datetime.datetime.now())
+        smt.system_schedulepackagerefresh(datetime.datetime.utcnow())
+        smt.system_schedulehardwarerefresh(datetime.datetime.utcnow())
     else:
         smt.log_error("SP Migration failed. No SP update available")
 
@@ -225,7 +225,7 @@ def remove_ltss():
             continue
         else:
             new_child_channels.append(child_channel.get('label'))
-    smt.system_schedulechangechannels(smt.system_getsubscribedbasechannel().get('label'), new_child_channels, datetime.datetime.now())
+    smt.system_schedulechangechannels(smt.system_getsubscribedbasechannel().get('label'), new_child_channels, datetime.datetime.utcnow())
     installed_packages = smt.system_listinstalledpackages()
     remove_packages = []
     for package in installed_packages:
@@ -235,8 +235,8 @@ def remove_ltss():
     if remove_packages:
         for x in remove_packages:
             script += "{} ".format(x)
-        smt.system_schedulescriptrun(script, 60, datetime.datetime.now())
-        smt.system_schedulepackagerefresh(datetime.datetime.now())
+        smt.system_schedulescriptrun(script, 60, datetime.datetime.utcnow())
+        smt.system_schedulepackagerefresh(datetime.datetime.utcnow())
     return
 
 
@@ -357,14 +357,14 @@ def do_update_script(phase):
     (script, list_channel, timeout) = read_update_script(phase, smt.hostname, script, list_channel)
     if script:
         smt.log_info("Execute {} update scripts".format(phase))
-        smt.system_schedulescriptrun("#!/bin/bash\n" + script, timeout, xmlrpc.client.DateTime(datetime.datetime.now()))
+        smt.system_schedulescriptrun("#!/bin/bash\n" + script, timeout, xmlrpc.client.DateTime(datetime.datetime.utcnow()))
     else:
         smt.log_info("There is no {} update script available for server.".format(phase))
     if list_channel:
         list_systems = [smt.systemid]
         smt.system_config_addchannels(list_systems, list_channel)
         smt.log_info("Performing high state for {} state channels".format(phase))
-        smt.system_scheduleapplyhighstate(xmlrpc.client.DateTime(datetime.datetime.now()))
+        smt.system_scheduleapplyhighstate(xmlrpc.client.DateTime(datetime.datetime.utcnow()))
         smt.system_config_removechannels(list_systems, list_channel)
         return True
     else:
@@ -385,7 +385,7 @@ def update_server(args):
         highstate_done = do_update_script("begin")
     if args.applyconfig and not highstate_done:
         if smt.system_getdetails().get('base_entitlement') == "salt_entitled":
-            smt.system_scheduleapplyhighstate(xmlrpc.client.DateTime(datetime.datetime.now()))
+            smt.system_scheduleapplyhighstate(xmlrpc.client.DateTime(datetime.datetime.utcnow()))
     (do_spm, new_basechannel) = check_for_sp_migration()
     if do_spm:
         smt.log_info("Server {} will get a SupportPack Migration to {} ".format(args.server, new_basechannel))
@@ -398,7 +398,7 @@ def update_server(args):
         highstate_done = do_update_script("end")
     if args.applyconfig and not highstate_done:
         if smt.system_getdetails().get('base_entitlement') == "salt_entitled":
-            smt.system_scheduleapplyhighstate(xmlrpc.client.DateTime(datetime.datetime.now()))
+            smt.system_scheduleapplyhighstate(xmlrpc.client.DateTime(datetime.datetime.utcnow()))
     if args.post_script:
         smt.log_info("Executing script {}".format(args.post_script))
         if os.path.isfile(args.post_script.split(" ")[0]):


### PR DESCRIPTION
When using this script with a new containerized Uyuni, I stumbled upon that the timezones between the Uyuni host and the actual contain differ:

```command
# timedatectl
               Local time: Tue 2025-05-13 15:26:51 CEST
           Universal time: Tue 2025-05-13 13:26:51 UTC
                 RTC time: Tue 2025-05-13 13:26:51
                Time zone: Europe/Berlin (CEST, +0200)
System clock synchronized: yes
              NTP service: active
          RTC in local TZ: no
```

```command
# mgrctl exec 'timedatectl'
               Local time: Tue 2025-05-13 13:26:58 UTC
           Universal time: Tue 2025-05-13 13:26:58 UTC
                 RTC time: n/a
                Time zone: Europe/Berlin (CEST, +0200)
System clock synchronized: yes
              NTP service: n/a
          RTC in local TZ: no
```

Therefore the scripts don't schedule actions immediately and an error occurs. This PR fixes the issue as described in #31.