### PR TITLE
Add files via upload

### DIFF
--- a/utils/mgrctl-watch-channel-sync
+++ b/utils/mgrctl-watch-channel-sync
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+###################################################
+#
+# The script will display the progress of latest
+# channel sync and update every 3 seconds
+#
+# Anthony Tortola 2019,2025
+#
+###################################################
+
+while [ 1 ]
+do
+        filename=`ls -tr /var/lib/containers/storage/volumes/var-log/_data/rhn/reposync|tail -1`
+        clear
+        echo -e "\nWatching $filename\n\n\tPress Ctrl-C to Break\n"
+        echo -e "\t$(date)\n"
+        tail -n20 /var/lib/containers/storage/volumes/var-log/_data/rhn/reposync/$filename
+        sleep 3
+done
+exit


### PR DESCRIPTION
Updated version of spacewalk-watch-channel-sync.sh.  Designed to be run outside of the unuyi server container.  spacewalk-watch-channel-sync.sh should be depricated.